### PR TITLE
Fix: "Checkout" form isn't responsive.

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -576,10 +576,6 @@
 		width: 100%;
 	}
 
-	.woocommerce-checkout .entry-content .woocommerce {
-		width: 600px;
-	}
-
 	.error-404.not-found .search-field {
 		width: 87%;
 	}


### PR DESCRIPTION
Chekout form isn't responsive because it's forced to have a width of 600px on screens up to 600px .