### PR TITLE
Fix/php error

### DIFF
--- a/inc/widgets/class-estore-featured-posts-carousel-widget.php
+++ b/inc/widgets/class-estore-featured-posts-carousel-widget.php
@@ -138,14 +138,14 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 							$image_id = get_post_thumbnail_id();
 							$image_url = wp_get_attachment_image_src($image_id,'estore-square', false); ?>
 							<figure class="featured-img">
-								<?php if($image_url[0]) { ?>
+								<?php if ( ! empty( $image_url[0] ) ) { ?>
 									<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="<?php the_title_attribute(); ?>">
 								<?php } else { ?>
 									<img src="<?php echo esc_url( get_template_directory_uri() . '/images/placeholder-blog.jpg' ); ?>" alt="<?php the_title_attribute(); ?>">
 								<?php } ?>
 								<div class="featured-hover-wrapper">
 									<div class="featured-hover-block">
-										<?php if($image_url[0]) { ?>
+										<?php if ( ! empty( $image_url[0] ) ) { ?>
 											<a href="<?php echo esc_url( $image_url[0] ); ?>" class="zoom" data-rel="prettyPhoto"><i class="fa fa-search-plus"></i></a>
 										<?php } else { ?>
 											<a href="<?php echo esc_url( get_template_directory_uri() . '/images/placeholder-blog.jpg' ); ?>" class="zoom" data-rel="prettyPhoto"><i class="fa fa-search-plus"></i></a>

--- a/inc/widgets/class-estore-featured-posts-carousel-widget.php
+++ b/inc/widgets/class-estore-featured-posts-carousel-widget.php
@@ -147,14 +147,14 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 							$image_url = wp_get_attachment_image_src( $image_id, 'estore-square', false );
 							?>
 							<figure class="featured-img">
-								<?php if ( ! empty( $image_url[0] ) ) { ?>
+								<?php if ( isset( $image_url[0] ) ) { ?>
 									<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="<?php the_title_attribute(); ?>">
 								<?php } else { ?>
 									<img src="<?php echo esc_url( get_template_directory_uri() . '/images/placeholder-blog.jpg' ); ?>" alt="<?php the_title_attribute(); ?>">
 								<?php } ?>
 								<div class="featured-hover-wrapper">
 									<div class="featured-hover-block">
-										<?php if ( ! empty( $image_url[0] ) ) { ?>
+										<?php if ( isset( $image_url[0] ) ) { ?>
 											<a href="<?php echo esc_url( $image_url[0] ); ?>" class="zoom" data-rel="prettyPhoto"><i class="fa fa-search-plus"></i></a>
 										<?php } else { ?>
 											<a href="<?php echo esc_url( get_template_directory_uri() . '/images/placeholder-blog.jpg' ); ?>" class="zoom" data-rel="prettyPhoto"><i class="fa fa-search-plus"></i></a>

--- a/inc/widgets/class-estore-featured-posts-carousel-widget.php
+++ b/inc/widgets/class-estore-featured-posts-carousel-widget.php
@@ -5,30 +5,31 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 	function __construct() {
 		$widget_ops = array(
 			'classname'   => 'slider_wrapper widget-featured-collection clearfix',
-			'description' => esc_html__( 'Display latest posts or posts of specific category, which will be used as the carousel.', 'estore' ) );
+			'description' => esc_html__( 'Display latest posts or posts of specific category, which will be used as the carousel.', 'estore' ),
+		);
 
 		$control_ops = array(
 			'width'  => 200,
-			'height' => 250
+			'height' => 250,
 		);
 
-		parent::__construct( false,$name= esc_html__( 'TG: Category Carousel', 'estore' ), $widget_ops);
+		parent::__construct( false, $name = esc_html__( 'TG: Category Carousel', 'estore' ), $widget_ops );
 	}
 
 	function form( $instance ) {
-		$tg_defaults[ 'title' ]     = '';
-		$tg_defaults[ 'subtitle' ]  = '';
-		$tg_defaults['number']      = 5;
-		$tg_defaults['type']        = 'latest';
-		$tg_defaults['category']    = '';
+		$tg_defaults['title']    = '';
+		$tg_defaults['subtitle'] = '';
+		$tg_defaults['number']   = 5;
+		$tg_defaults['type']     = 'latest';
+		$tg_defaults['category'] = '';
 
 		$instance = wp_parse_args( (array) $instance, $tg_defaults );
 
-		$title     = esc_attr( $instance[ 'title' ] );
-		$subtitle  = esc_textarea( $instance[ 'subtitle' ] );
-		$number    = $instance['number'];
-		$type      = $instance['type'];
-		$category  = $instance['category'];
+		$title    = esc_attr( $instance['title'] );
+		$subtitle = esc_textarea( $instance['subtitle'] );
+		$number   = $instance['number'];
+		$type     = $instance['type'];
+		$category = $instance['category'];
 		?>
 
 		<p>
@@ -36,17 +37,17 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>" />
 		</p>
 
-		<?php esc_html_e( 'Description:','estore' ); ?>
-		<textarea class="widefat" rows="5" cols="20" id="<?php echo $this->get_field_id( 'subtitle' ); ?>" name="<?php echo $this->get_field_name('subtitle'); ?>"><?php echo $subtitle; ?></textarea>
+		<?php esc_html_e( 'Description:', 'estore' ); ?>
+		<textarea class="widefat" rows="5" cols="20" id="<?php echo $this->get_field_id( 'subtitle' ); ?>" name="<?php echo $this->get_field_name( 'subtitle' ); ?>"><?php echo $subtitle; ?></textarea>
 
 		<p>
-			<label for="<?php echo $this->get_field_id('number'); ?>"><?php esc_html_e( 'Number of posts to display:', 'estore' ); ?></label>
-			<input id="<?php echo $this->get_field_id('number'); ?>" name="<?php echo $this->get_field_name('number'); ?>" type="text" value="<?php echo $number; ?>" size="3" />
+			<label for="<?php echo $this->get_field_id( 'number' ); ?>"><?php esc_html_e( 'Number of posts to display:', 'estore' ); ?></label>
+			<input id="<?php echo $this->get_field_id( 'number' ); ?>" name="<?php echo $this->get_field_name( 'number' ); ?>" type="text" value="<?php echo $number; ?>" size="3" />
 		</p>
 
 		<p>
-			<input type="radio" <?php checked($type, 'latest') ?> id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>" value="latest"/><?php esc_html_e( 'Show latest Posts', 'estore' );?><br />
-			<input type="radio" <?php checked($type,'category') ?> id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>" value="category"/><?php esc_html_e( 'Show posts from a category', 'estore' );?><br />
+			<input type="radio" <?php checked( $type, 'latest' ); ?> id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>" value="latest"/><?php esc_html_e( 'Show latest Posts', 'estore' ); ?><br />
+			<input type="radio" <?php checked( $type, 'category' ); ?> id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>" value="category"/><?php esc_html_e( 'Show posts from a category', 'estore' ); ?><br />
 		</p>
 
 		<p>
@@ -54,9 +55,9 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 			<?php
 			wp_dropdown_categories(
 				array(
-					'show_option_none' =>' ',
+					'show_option_none' => ' ',
 					'name'             => $this->get_field_name( 'category' ),
-					'selected'         => $category
+					'selected'         => $category,
 				)
 			);
 			?>
@@ -68,15 +69,16 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 	function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 
-		$instance[ 'title' ]        = sanitize_text_field( $new_instance[ 'title' ] );
-		if ( current_user_can('unfiltered_html') )
-			$instance[ 'subtitle' ] =  $new_instance[ 'subtitle' ];
-		else
-			$instance[ 'subtitle' ] = stripslashes( wp_filter_post_kses( addslashes( $new_instance[ 'subtitle' ] ) ) );
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			$instance['subtitle'] = $new_instance['subtitle'];
+		} else {
+			$instance['subtitle'] = stripslashes( wp_filter_post_kses( addslashes( $new_instance['subtitle'] ) ) );
+		}
 
-		$instance[ 'number' ]   = absint( $new_instance[ 'number' ] );
-		$instance[ 'type' ]     = $new_instance[ 'type' ];
-		$instance[ 'category' ] = $new_instance[ 'category' ];
+		$instance['number']   = absint( $new_instance['number'] );
+		$instance['type']     = $new_instance['type'];
+		$instance['category'] = $new_instance['category'];
 
 		return $instance;
 	}
@@ -86,25 +88,28 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 		extract( $instance );
 
 		global $post;
-		$title    = apply_filters( 'widget_title', isset( $instance[ 'title' ] ) ? $instance[ 'title' ] : '');
-		$subtitle = isset( $instance[ 'subtitle' ] ) ? $instance[ 'subtitle' ] : '';
-		$number   = empty( $instance[ 'number' ] ) ? 5 : $instance[ 'number' ];
-		$type     = isset( $instance[ 'type' ] ) ? $instance[ 'type' ] : 'latest' ;
-		$category = isset( $instance[ 'category' ] ) ? $instance[ 'category' ] : '';
+		$title    = apply_filters( 'widget_title', isset( $instance['title'] ) ? $instance['title'] : '' );
+		$subtitle = isset( $instance['subtitle'] ) ? $instance['subtitle'] : '';
+		$number   = empty( $instance['number'] ) ? 5 : $instance['number'];
+		$type     = isset( $instance['type'] ) ? $instance['type'] : 'latest';
+		$category = isset( $instance['category'] ) ? $instance['category'] : '';
 
-		if( $type == 'latest' ) {
-			$get_featured_posts = new WP_Query( array(
-				'posts_per_page'        => $number,
-				'post_type'             => 'post',
-				'ignore_sticky_posts'   => true
-			) );
-		}
-		else {
-			$get_featured_posts = new WP_Query( array(
-				'posts_per_page'        => $number,
-				'post_type'             => 'post',
-				'category__in'          => $category
-			) );
+		if ( $type == 'latest' ) {
+			$get_featured_posts = new WP_Query(
+				array(
+					'posts_per_page'      => $number,
+					'post_type'           => 'post',
+					'ignore_sticky_posts' => true,
+				)
+			);
+		} else {
+			$get_featured_posts = new WP_Query(
+				array(
+					'posts_per_page' => $number,
+					'post_type'      => 'post',
+					'category__in'   => $category,
+				)
+			);
 		}
 
 		// For Multilingual compatibility
@@ -112,18 +117,20 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 			icl_register_string( 'eStore', 'TG: Category Carousel Subtitle' . $this->id, $subtitle );
 		}
 		if ( function_exists( 'icl_t' ) ) {
-			$subtitle  = icl_t( 'eStore', 'TG: Category Carousel Subtitle'. $this->id, $subtitle );
+			$subtitle = icl_t( 'eStore', 'TG: Category Carousel Subtitle' . $this->id, $subtitle );
 		}
 		echo $before_widget;
 		?>
 		<div class="tg-container">
 			<div class="section-title-wrapper clearfix">
 				<div class="section-title-block">
-					<?php if ( !empty( $title ) ) { ?>
+					<?php if ( ! empty( $title ) ) { ?>
 						<h3 class="page-title"><?php echo esc_html( $title ); ?></h3>
-					<?php }
-					if ( !empty( $subtitle ) ) { ?>
-						<h4 class="page-sub-title"><?php echo esc_textarea( $subtitle );?></h4>
+						<?php
+					}
+					if ( ! empty( $subtitle ) ) {
+						?>
+						<h4 class="page-sub-title"><?php echo esc_textarea( $subtitle ); ?></h4>
 					<?php } ?>
 				</div>
 			</div>
@@ -131,12 +138,14 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 				<ul class="featured-slider">
 					<?php
 
-					while ($get_featured_posts->have_posts()) :
-						$get_featured_posts->the_post(); ?>
+					while ( $get_featured_posts->have_posts() ) :
+						$get_featured_posts->the_post();
+						?>
 						<li>
 							<?php
-							$image_id = get_post_thumbnail_id();
-							$image_url = wp_get_attachment_image_src($image_id,'estore-square', false); ?>
+							$image_id  = get_post_thumbnail_id();
+							$image_url = wp_get_attachment_image_src( $image_id, 'estore-square', false );
+							?>
 							<figure class="featured-img">
 								<?php if ( ! empty( $image_url[0] ) ) { ?>
 									<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="<?php the_title_attribute(); ?>">
@@ -156,10 +165,10 @@ class estore_featured_posts_carousel_widget extends WP_Widget {
 							</figure>
 							<div class="featured-content-wrapper">
 								<h3 class="featured-title"> <a title="<?php the_title_attribute(); ?>" href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
-								<a href="<?php the_permalink(); ?>" class="single_add_to_wishlist" ><?php esc_html_e('Read More','estore'); ?><i class="fa fa-heart"></i></a>
+								<a href="<?php the_permalink(); ?>" class="single_add_to_wishlist" ><?php esc_html_e( 'Read More', 'estore' ); ?><i class="fa fa-heart"></i></a>
 							</div><!-- featured content wrapper -->
 						</li>
-					<?php
+						<?php
 					endwhile;
 					?>
 				</ul>


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixed PHP error issue seen in TG: Category Carousel widget of eStore theme.
### Type of change
- [ ] Code Refactor
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
Add widgets via **Widgets > Front Page Sidebar > TG: Category Carousel**

### Checklist:
- [x] My code follows WordPress' coding standards
- [x] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform a test that proves my fix is effective or that my feature works
### Did you test this issue fix on all browsers?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] opera
### Changelog entry
A changelog is not required.