### PR TITLE
Add/font display

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -162,7 +162,7 @@ function estore_scripts() {
 
 	wp_enqueue_script( 'superfish', get_template_directory_uri() . '/js/superfish' . $suffix . '.js', array( 'jquery' ), false, true );
 
-	wp_enqueue_style( 'estore-googlefonts', '//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300' );
+	wp_enqueue_style( 'estore-googlefonts', '//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300&display=swap' );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/readme.txt
+++ b/readme.txt
@@ -84,7 +84,7 @@ If you want the theme to be translated into your language, feel free to contribu
 
 == Changelog ==
 = Version TBD =
-* Fix - Font display swap property and value for google fonts.
+* Enhancement - Added 'font-display: swap' CSS property for fonts to ensure better load performance.
 
 = Version 1.5.9 - 2021-05-07 =
 * Fix - Shop page responsive design issue.

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,9 @@ If you want the theme to be translated into your language, feel free to contribu
 /**********************************************************/
 
 == Changelog ==
+= Version TBD =
+* Fix - Font display swap property and value for google fonts.
+
 = Version 1.5.9 - 2021-05-07 =
 * Fix - Shop page responsive design issue.
 * Tweak - Update screenshot image source link.


### PR DESCRIPTION
### Changes proposed in this Pull Request
>Adds 'font-display:swap' CSS property for fonts. This ensures that our fonts remains visible and also ensures better load performance.
### Type of change
- [ ] Code Refactor
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
1. Use google inbuilt tool "Light House".
2. Change fonts options from the customizer.
3. There must not be any error related to fonts that say "Ensure fonts remains visible during page reload".

### Checklist:
- [x] My code follows WordPress' coding standards
- [ ] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have made perform a test that proves my fix is effective or that my feature works
### Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] opera
### Changelog entry
> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.