### PR TITLE
Fixed image size issue on importing demo

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -302,21 +302,20 @@ if ( ! function_exists( 'estore_template_loop_product_thumbnail' ) ) {
 	 *
 	 * @subpackage    Loop
 	 *
-	 * @param string $size (default: 'shop_catalog')
+	 * @param string $size (default: 'woocommerce_thumbnail')
 	 *
 	 * @return string
 	 */
 	function estore_template_loop_product_thumbnail() {
 		global $product, $post;
 
-		$size = 'shop_catalog';
+		$size = 'woocommerce_thumbnail';
 
 		if ( has_post_thumbnail() ) {
 			$image_id  = get_post_thumbnail_id( $post->ID );
 			$image_url = wp_get_attachment_image_src( $image_id, $size, false ); ?>
 			<figure class="products-img">
-				<a href="<?php echo esc_url( get_permalink( $product->get_id() ) ); ?>" alt="<?php the_title(); ?>"><img
-							src="<?php echo esc_url( $image_url[0] ); ?>"></a>
+				<a href="<?php echo esc_url( get_permalink( $product->get_id() ) ); ?>" alt="<?php the_title(); ?>"><?php woocommerce_template_loop_product_thumbnail() ?></a>
 				<?php if ( $product->is_on_sale() ) : ?>
 					<?php echo apply_filters( 'woocommerce_sale_flash', '<div class="sales-tag">' . esc_html__( 'Sale!', 'estore' ) . '</div>', $post, $product ); ?>
 				<?php endif; ?>

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -315,7 +315,7 @@ if ( ! function_exists( 'estore_template_loop_product_thumbnail' ) ) {
 			$image_id  = get_post_thumbnail_id( $post->ID );
 			$image_url = wp_get_attachment_image_src( $image_id, $size, false ); ?>
 			<figure class="products-img">
-				<a href="<?php echo esc_url( get_permalink( $product->get_id() ) ); ?>" alt="<?php the_title(); ?>"><?php woocommerce_template_loop_product_thumbnail() ?></a>
+				<a href="<?php echo esc_url( get_permalink( $product->get_id() ) ); ?>" alt="<?php the_title(); ?>"><?php woocommerce_template_loop_product_thumbnail(); ?></a>
 				<?php if ( $product->is_on_sale() ) : ?>
 					<?php echo apply_filters( 'woocommerce_sale_flash', '<div class="sales-tag">' . esc_html__( 'Sale!', 'estore' ) . '</div>', $post, $product ); ?>
 				<?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,9 @@ If you want the theme to be translated into your language, feel free to contribu
 /**********************************************************/
 
 == Changelog ==
+= Version TBD =
+* Fix - WooCommerce product thumbnail size issue.
+
 = Version 1.6.1 - 2021-08-02 =
 * Fix - Mobile design issue of read more button on slider.
 


### PR DESCRIPTION
What is done in this PR?

- Fixed inappropriate image size on importing demo.

How to test?

- On a fresh install of eStore, import the demo.
- The demo images should be sized properly as in themegrilldemos.com/estore
